### PR TITLE
feat: create live heading depths test

### DIFF
--- a/lib/md-test.test.ts
+++ b/lib/md-test.test.ts
@@ -1,0 +1,23 @@
+import {remark} from 'remark'
+import {allHeadingDepthsTest} from './md-test'
+
+describe('allHeadingDepthsTest', () => {
+  test('reports missing headings', async () => {
+    const text = `Hello World`
+    const result = await remark().use(allHeadingDepthsTest).process(text)
+    expect(result.data.missingHeadings).toEqual([1, 2, 3, 4, 5, 6])
+  })
+
+  test('reports no missing headings if all are present', async () => {
+    const text = `
+# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+    `.trim()
+    const result = await remark().use(allHeadingDepthsTest).process(text)
+    expect(result.data.missingHeadings).toEqual([])
+  })
+})

--- a/lib/md-test.test.ts
+++ b/lib/md-test.test.ts
@@ -20,4 +20,17 @@ describe('allHeadingDepthsTest', () => {
     const result = await remark().use(allHeadingDepthsTest).process(text)
     expect(result.data.missingHeadings).toEqual([])
   })
+
+  test('reports empty headings as failures', async () => {
+    const text = `
+#
+##
+###
+####
+#####
+######
+    `.trim()
+    const result = await remark().use(allHeadingDepthsTest).process(text)
+    expect(result.data.missingHeadings).toEqual([1, 2, 3, 4, 5, 6])
+  })
 })

--- a/lib/md-test.ts
+++ b/lib/md-test.ts
@@ -10,7 +10,16 @@ export const allHeadingDepthsTest = () => (tree: Root, file: VFile) => {
 
   // visit each `heading` node and add its depth to the "found" list
   visit(tree, 'heading', (node) => {
-    foundHeadings.add(node.depth)
+    // check that we have a child `text` with actual text in its `value`
+    const hasValidTextChild = Boolean(
+      node.children.find(
+        (child) => child.type === 'text' && child.value.length,
+      ),
+    )
+
+    if (hasValidTextChild) {
+      foundHeadings.add(node.depth)
+    }
   })
 
   // missing headings are the difference between the required headings and the

--- a/lib/md-test.ts
+++ b/lib/md-test.ts
@@ -4,11 +4,13 @@ import {visit} from 'unist-util-visit'
 
 export const allHeadingDepthsTest = () => (tree: Root, file: VFile) => {
   const requiredHeadings = [1, 2, 3, 4, 5, 6]
-  const foundHeadings: number[] = []
+
+  // we use a `Set` here so we don't needlessly store duplicate found depths
+  const foundHeadings = new Set<number>()
 
   // visit each `heading` node and add its depth to the "found" list
   visit(tree, 'heading', (node) => {
-    foundHeadings.push(node.depth)
+    foundHeadings.add(node.depth)
   })
 
   // missing headings are the difference between the required headings and the
@@ -16,7 +18,7 @@ export const allHeadingDepthsTest = () => (tree: Root, file: VFile) => {
   const missingHeadings = requiredHeadings.filter(
     (heading) =>
       // if the heading isn't in the "found" list, it's missing!
-      !foundHeadings.includes(heading),
+      !foundHeadings.has(heading),
   )
 
   // attach the missing headings to our `VFile`'s `data`

--- a/lib/md-test.ts
+++ b/lib/md-test.ts
@@ -1,0 +1,24 @@
+import type {Root} from 'mdast'
+import type {VFile} from 'vfile'
+import {visit} from 'unist-util-visit'
+
+export const allHeadingDepthsTest = () => (tree: Root, file: VFile) => {
+  const requiredHeadings = [1, 2, 3, 4, 5, 6]
+  const foundHeadings: number[] = []
+
+  // visit each `heading` node and add its depth to the "found" list
+  visit(tree, 'heading', (node) => {
+    foundHeadings.push(node.depth)
+  })
+
+  // missing headings are the difference between the required headings and the
+  // found headings
+  const missingHeadings = requiredHeadings.filter(
+    (heading) =>
+      // if the heading isn't in the "found" list, it's missing!
+      !foundHeadings.includes(heading),
+  )
+
+  // attach the missing headings to our `VFile`'s `data`
+  file.data.missingHeadings = missingHeadings
+}

--- a/package.json
+++ b/package.json
@@ -10,9 +10,13 @@
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest"
   },
   "dependencies": {
+    "mdast": "^3.0.0",
     "next": "11.1.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "remark": "^14.0.1",
+    "unist-util-visit": "^4.1.0",
+    "vfile": "^5.2.0",
     "xdm": "^3.0.1"
   },
   "devDependencies": {

--- a/pages/headings.tsx
+++ b/pages/headings.tsx
@@ -1,0 +1,40 @@
+import {useState} from 'react'
+import {remark} from 'remark'
+import {MarkdownPreview} from '../components/MarkdownPreview'
+import {allHeadingDepthsTest} from '../lib/md-test'
+
+export default function Headings() {
+  const [source, setSource] = useState('')
+  const result = remark().use(allHeadingDepthsTest).processSync(source)
+  const missingHeadings = result.data.missingHeadings as number[]
+
+  const HeadingTest = ({depth}: {depth: number}) => {
+    // if `depth` is in `missingHeadings`, the test should fail
+    const isFail = missingHeadings.includes(depth)
+    const symbol = isFail ? '❌' : '✅'
+    return (
+      <>
+        {symbol} Heading depth {depth}
+      </>
+    )
+  }
+
+  return (
+    <div>
+      <ul>
+        {[1, 2, 3, 4, 5, 6].map((depth) => (
+          <li key={depth}>
+            <HeadingTest depth={depth} />
+          </li>
+        ))}
+      </ul>
+      <textarea
+        value={source}
+        onChange={(event) => setSource(event.target.value)}
+        cols={40}
+        rows={20}
+      />
+      <MarkdownPreview source={source} />
+    </div>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4056,6 +4056,11 @@ mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz#56c506d065fbf769515235e577b5a261552d56e9"
   integrity sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==
 
+mdast@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mdast/-/mdast-3.0.0.tgz#626bce9603ed43fb6fb053245a6e4a17f4457aa8"
+  integrity sha1-YmvOlgPtQ/tvsFMkWm5KF/RFeqg=
+
 mdurl@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
@@ -5193,6 +5198,25 @@ remark-rehype@^10.0.0:
     mdast-util-to-hast "^12.0.0"
     unified "^10.0.0"
 
+remark-stringify@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-10.0.1.tgz#9422dd20803892570a5e3d16801ffe081340ff06"
+  integrity sha512-380vOu9EHqRTDhI9RlPU2EKY1abUDEmxw9fW7pJ/8Jr1izk0UcdnZB30qiDDRYi6pGn5FnVf9Wd2iUeCWTqM7Q==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-markdown "^1.0.0"
+    unified "^10.0.0"
+
+remark@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-14.0.1.tgz#a97280d4f2a3010a7d81e6c292a310dcd5554d80"
+  integrity sha512-7zLG3u8EUjOGuaAS9gUNJPD2j+SqDqAFHv2g6WMpE5CU9rZ6e3IKDM12KHZ3x+YNje+NMAuN55yx8S5msGSx7Q==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    remark-parse "^10.0.0"
+    remark-stringify "^10.0.0"
+    unified "^10.0.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -5943,7 +5967,7 @@ unist-util-visit@^3.0.0:
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^4.0.0"
 
-unist-util-visit@^4.0.0:
+unist-util-visit@^4.0.0, unist-util-visit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.0.tgz#f41e407a9e94da31594e6b1c9811c51ab0b3d8f5"
   integrity sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==
@@ -6052,6 +6076,16 @@ vfile@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.1.1.tgz#d71576553720f73123b72f4b100d9ac95bc9164d"
   integrity sha512-sfI+3MnGUodvAE2s3hXCcJxhcymXQgekdgqNf9WMcmWtZU65tPMaml5eGYREJfMJGHr4/0GPZgrN3UMgWjHXSQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
+
+vfile@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.2.0.tgz#a32a646ff9251c274dbe8675644a39031025b369"
+  integrity sha512-ftCpb6pU8Jrzcqku8zE6N3Gi4/RkDhRwEXSWudzZzA2eEOn/cBpsfk9aulCUR+j1raRSAykYQap9u6j6rhUaCA==
   dependencies:
     "@types/unist" "^2.0.0"
     is-buffer "^2.0.0"


### PR DESCRIPTION
This PR includes a number of changes that allow us to test user input to validate their understanding of page content:

- adds the `allHeadingDepthsTest` plugin for `remark` (and tests for the plugin)
- uses the plugin in the new `/headings` page to test user input
- displays a pass/fail message for each heading depth